### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "express-rate-limit": "^7.5.1"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,4 +1,5 @@
 import express, { type Express } from "express";
+import rateLimit from "express-rate-limit";
 import fs from "fs";
 import path from "path";
 import { createServer as createViteServer, createLogger } from "vite";
@@ -78,8 +79,14 @@ export function serveStatic(app: Express) {
 
   app.use(express.static(distPath));
 
+  // Configure rate limiter: maximum of 100 requests per 15 minutes
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+  });
+
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
+  app.use("*", limiter, (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/FBT/security/code-scanning/2](https://github.com/CreoDAMO/FBT/security/code-scanning/2)

To address the issue, we will introduce rate limiting to the route handler that serves the `index.html` file. The `express-rate-limit` package is a widely used middleware for rate limiting in Express applications. We will configure it to allow a maximum number of requests within a specified time window (e.g., 100 requests per 15 minutes). This will mitigate the risk of denial-of-service attacks by limiting the frequency of requests to the route.

**Steps to fix:**
1. Install the `express-rate-limit` package if not already installed.
2. Import the package in `server/vite.ts`.
3. Configure a rate limiter with appropriate settings (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter middleware to the route handler serving the `index.html` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
