### PR TITLE
Potential fix for code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,5 +1,6 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
+import rateLimit from "express-rate-limit";
 import { WebSocketServer } from "ws";
 import { storage } from "./storage";
 import { setupAuth } from "./auth";
@@ -10,6 +11,14 @@ import { aiRoutes } from "./ai/routes";
 export async function registerRoutes(app: Express): Promise<Server> {
   // Setup comprehensive authentication system
   const authenticateJWT = setupAuth(app);
+
+  // Rate limiter for AI routes
+  const aiRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
 
   // Dashboard metrics
   app.get("/api/dashboard/metrics", async (req, res) => {
@@ -327,7 +336,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // AI routes - protected with JWT authentication
-  app.use("/api/ai", authenticateJWT, aiRoutes);
+  app.use("/api/ai", aiRateLimiter, authenticateJWT, aiRoutes);
 
   // WebSocket server for real-time updates
   const httpServer = createServer(app);


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/FBT/security/code-scanning/8](https://github.com/CreoDAMO/FBT/security/code-scanning/8)

To fix the missing rate limiting, we should add a rate limiter middleware to the `/api/ai` route. The best practice is to use a well-known, battle-tested middleware such as `express-rate-limit`. The fix involves importing the `express-rate-limit` package, creating a suitable limiter (e.g., 100 requests per 15 minutes per IP, or stricter limits depending on AI cost), and applying it directly to the `/api/ai` route—before the authentication and route handler. This means editing the `server/routes.ts` file to add the import, define the limiter, and update the line for `.use("/api/ai", ...)` to include the new limiter as middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
