### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -386,7 +386,12 @@ export function setupAuth(app: Express) {
   });
 
   // Web3 wallet login
-  app.post("/api/auth/wallet-login", async (req, res) => {
+  const walletLoginLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 10, // limit each IP to 10 requests per windowMs
+    message: { message: "Too many wallet login attempts, please try again later." },
+  });
+  app.post("/api/auth/wallet-login", walletLoginLimiter, async (req, res) => {
     try {
       const { walletAddress, provider } = req.body;
       


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/FBT/security/code-scanning/5](https://github.com/CreoDAMO/FBT/security/code-scanning/5)

To fix the problem, apply a rate limiter middleware specifically to the `/api/auth/wallet-login` POST route. A conservative approach is to use the same `express-rate-limit` package already imported as `rateLimit`, but configure a suitable limit (e.g., 10 requests per 15 minutes per IP for wallet logins). This involves:

- Define a rate limiter instance (e.g., `walletLoginLimiter`) near where the routes are set up.
- Add this limiter as middleware in the route definition for `/api/auth/wallet-login`.
- Only touch `server/auth.ts`. Do not assume any edits to files or code not shown.

Implementation steps:

- Define a limiter variable before its use, e.g., just above the route definitions.
- Apply the limiter as the first argument to `app.post("/api/auth/wallet-login", ...)`.
- No new methods or imports are required, as `express-rate-limit` is already imported as `rateLimit`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
