### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy to GitHub Pages and Vercel
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/FBT/security/code-scanning/9](https://github.com/CreoDAMO/FBT/security/code-scanning/9)

To fix the issue, explicitly declare a `permissions` block either at the workflow level (applies to all jobs) or at the job level (for finer control). In this case, since only one job is present, the most direct and readable solution is to add a workflow-level `permissions` block directly after the `name` (before `on:`), specifying the minimal permissions required by the deploy steps.

- The deployment to GitHub Pages via `peaceiris/actions-gh-pages` needs `contents: write` access to push to the `gh-pages` branch.
- For Vercel deployment, the action typically uses provided tokens/secrets, not GITHUB_TOKEN, and does not need special GitHub permissions.
- Therefore, set at minimum: `contents: write` (for the GITHUB_TOKEN capabilities).

**Steps to implement:**
- In `.github/workflows/deploy.yml`, add after `name: ...` and before `on: ...`:
  ```yaml
  permissions:
    contents: write
  ```
No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
